### PR TITLE
Fix "module 'luarocks.cfg' not found" error.

### DIFF
--- a/lub/init.lua
+++ b/lub/init.lua
@@ -84,7 +84,7 @@ local SYSTINFO
 --
 function lib.plat()
   if not SYSTINFO then
-    local cfg = require 'luarocks.cfg'
+    local cfg = require 'luarocks.core.cfg'
     local ok, system = pcall(function()
       return io.popen("uname -s"):read("*l")
     end)


### PR DESCRIPTION
You can see that cfg.lua is now in a core folder (source: https://github.com/luarocks/luarocks/blob/master/src/luarocks/core/cfg.lua). I tried to use dub which uses lub but I received this error. Making this change let me continue on and make a Lua binding.